### PR TITLE
Prompt for duffle.toml components array with directory names

### DIFF
--- a/src/completion/duffle.toml.completions.ts
+++ b/src/completion/duffle.toml.completions.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class DuffleTOMLCompletionProvider implements vscode.CompletionItemProvider {
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
+        const wordPos = document.getWordRangeAtPosition(position) || new vscode.Range(position, position);
+        const line = document.lineAt(position.line).text;
+        const lineUntil = line.substr(0, wordPos.start.character).trim();
+
+        if (shouldPrompt(lineUntil)) {
+            const tomlPath = document.uri.fsPath;
+            const completionItems =
+                subdirectories(tomlPath)
+                    .filter((d) => !d.startsWith('.'))
+                    .map((d) => new vscode.CompletionItem(`"${d}"`));
+            return new vscode.CompletionList(completionItems);
+        }
+
+        return [];
+    }
+}
+
+function subdirectories(filePath: string): string[] {
+    const fileDir = path.dirname(filePath);
+    const entries = fs.readdirSync(fileDir);
+    return entries.filter((d) => fs.statSync(path.join(fileDir, d)).isDirectory());
+}
+
+function shouldPrompt(lineUntil: string): boolean {
+    if (lineUntil.indexOf("components") < 0) {
+        return false;
+    }
+    return (lineUntil.endsWith("["))
+        || (lineUntil.endsWith(",") && lineUntil.indexOf("[") >= 0 && lineUntil.indexOf("]") < 0);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,17 +7,20 @@ import { BundleExplorer } from './explorer/bundle/bundle-explorer';
 import { RepoExplorer } from './explorer/repo/repo-explorer';
 import * as shell from './utils/shell';
 import * as duffle from './duffle/duffle';
+import { DuffleTOMLCompletionProvider } from './completion/duffle.toml.completions';
 
 export function activate(context: vscode.ExtensionContext) {
     const bundleExplorer = new BundleExplorer(shell.shell);
     const repoExplorer = new RepoExplorer(shell.shell);
+    const duffleTOMLCompletionProvider = new DuffleTOMLCompletionProvider();
 
     const subscriptions = [
         vscode.commands.registerCommand('duffle.refreshBundleExplorer', () => bundleExplorer.refresh()),
         vscode.commands.registerCommand('duffle.bundleStatus', (node) => bundleStatus(node)),
         vscode.commands.registerCommand('duffle.refreshRepoExplorer', () => repoExplorer.refresh()),
         vscode.window.registerTreeDataProvider("duffle.bundleExplorer", bundleExplorer),
-        vscode.window.registerTreeDataProvider("duffle.repoExplorer", repoExplorer)
+        vscode.window.registerTreeDataProvider("duffle.repoExplorer", repoExplorer),
+        vscode.languages.registerCompletionItemProvider({ language: 'toml', pattern: '**/duffle.toml', scheme: 'file' }, duffleTOMLCompletionProvider, '[', ',')
     ];
 
     context.subscriptions.push(...subscriptions);


### PR DESCRIPTION
In `duffle.toml` we have a `components` array which is meant to contain directory names relative to the TOML file that are to be built as referenced containers.  This completion provider suggests appropriate directory names when the user hits `[` or `,` on the `components` line.