### PR TITLE
Use repo/bundle syntax for install from repo

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,7 +155,7 @@ function repoBundleSelection(bundle: RepoBundle): BundleSelection {
         kind: 'repo',
         label: bundle.name,
         path: '',
-        bundle: bundle.name
+        bundle: `${bundle.repository}/${bundle.name}`
     };
 }
 


### PR DESCRIPTION
Previously `duffle install` took a bundle name e.g. `duffle install myapp foo`.  This was ambiguous if more than one repo included a bundle called `foo`, so you could end up with the wrong `foo` getting installed.  Ambiguous references now produce an error, and the install command supports references in the form `repo/bundle`.  This PR switches us over to always use that form and therefore avoid ambiguity errors.