### PR TITLE
Publish bundle to (local) repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "onCommand:duffle.bundleStatus",
         "onCommand:duffle.bundleUpgrade",
         "onCommand:duffle.build",
+        "onCommand:duffle.publish",
         "onCommand:duffle.install",
         "onCommand:duffle.refreshRepoExplorer",
         "onView:duffle.bundleExplorer",
@@ -53,6 +54,11 @@
             {
                 "command": "duffle.build",
                 "title": "Build Bundle",
+                "category": "Duffle"
+            },
+            {
+                "command": "duffle.publish",
+                "title": "Publish Bundle to Repo",
                 "category": "Duffle"
             },
             {
@@ -123,6 +129,11 @@
             "explorer/context": [
                 {
                     "command": "duffle.install",
+                    "when": "resourceFilename == bundle.json",
+                    "group": "9"
+                },
+                {
+                    "command": "duffle.publish",
                     "when": "resourceFilename == bundle.json",
                     "group": "9"
                 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,93 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { promptBundle, fileBundleSelection, BundleSelection } from '../utils/bundleselection';
+import { showDuffleResult, refreshRepoExplorer, longRunning } from '../utils/host';
+import { succeeded, Errorable, map, failed } from '../utils/errorable';
+import { cantHappen } from '../utils/never';
+import * as duffle from '../duffle/duffle';
+import * as shell from '../utils/shell';
+import { promisify } from 'util';
+
+export async function publish(target?: any): Promise<void> {
+    if (!target) {
+        return await publishPrompted();
+    }
+    if (target.scheme) {
+        return await publishFile(target as vscode.Uri);
+    }
+    await vscode.window.showErrorMessage("Internal error: unexpected command target");
+}
+
+async function publishPrompted(): Promise<void> {
+    const bundlePick = await promptBundle("Select the bundle to publish");
+
+    if (!bundlePick) {
+        return;
+    }
+
+    return await publishCore(bundlePick);
+}
+
+async function publishFile(file: vscode.Uri): Promise<void> {
+    if (file.scheme !== 'file') {
+        vscode.window.showErrorMessage("This command requires a filesystem bundle");
+        return;
+    }
+    return await publishCore(fileBundleSelection(file));
+}
+
+async function publishCore(bundlePick: BundleSelection): Promise<void> {
+    const name = await promptRepo(shell.shell, `Publish bundle in ${bundlePick.label} to...`);
+    if (!name) {
+        return;
+    }
+
+    const publishResult = await publishTo(bundlePick, name);
+
+    if (succeeded(publishResult)) {
+        await refreshRepoExplorer();
+    }
+
+    await showDuffleResult('publish', (bundleId) => bundleId, publishResult);
+}
+
+async function publishTo(bundlePick: BundleSelection, repo: string): Promise<Errorable<string>> {
+    if (bundlePick.kind === 'folder') {
+        const folderPath = bundlePick.path;
+        const bundlePath = path.join(folderPath, "cnab", "bundle.json");
+        const repoBundlesDir = path.join(duffle.home(shell.shell), "repositories", repo, "bundles");
+        const repoPath = path.join(repoBundlesDir, `${bundlePick.label}.json`);
+        const publishResult = await longRunning(`Duffle publishing ${bundlePath}`,
+            () => publishByCopying(bundlePath, repoPath)
+        );
+        return map(publishResult, (_) => bundlePath);
+    } else if (bundlePick.kind === 'repo') {
+        return { succeeded: false, error: ['Internal error - cannot publish bundles already in repos'] };
+    }
+    return cantHappen(bundlePick);
+}
+
+async function publishByCopying(sourcePath: string, repoPath: string): Promise<Errorable<null>> {
+    try {
+        await promisify(fs.copyFile)(sourcePath, repoPath);  // TODO: replace with promisified fs layer once merged
+        return { succeeded: true, result: null };
+    } catch (e) {
+        return { succeeded: false, error: [`Error copying ${sourcePath} to ${repoPath}: ${e}`] };
+    }
+}
+
+async function promptRepo(shell: shell.Shell, prompt: string): Promise<string | undefined> {
+    const repos = await duffle.listRepos(shell);
+    if (failed(repos)) {
+        vscode.window.showErrorMessage("Unable to list repos to which you can publish");
+        return undefined;
+    }
+    if (!repos.result || !repos.result.length) {
+        vscode.window.showErrorMessage("You don't have any repos to which you can publish");
+        return undefined;
+    }
+    const repo = await vscode.window.showQuickPick(repos.result, { placeHolder: prompt });
+    return repo;
+}

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -35,6 +35,10 @@ function andLog<T>(fn: (s: string) => T): (s: string) => T {
     };
 }
 
+export function home(sh: shell.Shell): string {
+    return process.env['DUFFLE_HOME'] || path.join(sh.home(), '.duffle');
+}
+
 export function list(sh: shell.Shell): Promise<Errorable<string[]>> {
     function parse(stdout: string): string[] {
         return stdout.split('\n')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as shell from './utils/shell';
 import * as duffle from './duffle/duffle';
 import { DuffleTOMLCompletionProvider } from './completion/duffle.toml.completions';
 import { selectWorkspaceFolder, longRunning, showDuffleResult, refreshBundleExplorer } from './utils/host';
+import { publish } from './commands/publish';
 import { install } from './commands/install';
 import { lintTo } from './lint/linters';
 import { succeeded } from './utils/errorable';
@@ -26,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('duffle.bundleUpgrade', (node) => bundleUpgrade(node)),
         vscode.commands.registerCommand('duffle.bundleUninstall', (node) => bundleUninstall(node)),
         vscode.commands.registerCommand('duffle.build', build),
+        vscode.commands.registerCommand('duffle.publish', publish),
         vscode.commands.registerCommand('duffle.install', install),
         vscode.commands.registerCommand('duffle.refreshRepoExplorer', () => repoExplorer.refresh()),
         vscode.window.registerTreeDataProvider("duffle.bundleExplorer", bundleExplorer),

--- a/src/utils/bundleselection.ts
+++ b/src/utils/bundleselection.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+import { selectQuickPick } from './host';
+import { RepoBundle } from '../duffle/duffle.objectmodel';
+
+export interface FolderBundleSelection {
+    readonly kind: 'folder';
+    readonly label: string;
+    readonly path: string;
+}
+
+export interface RepoBundleSelection {
+    readonly kind: 'repo';
+    readonly label: string;
+    readonly bundle: string;
+}
+
+export type BundleSelection = FolderBundleSelection | RepoBundleSelection;
+
+export async function promptBundle(prompt: string): Promise<BundleSelection | undefined> {
+    const bundles = await vscode.workspace.findFiles('**/cnab/bundle.json');
+    if (!bundles || bundles.length === 0) {
+        await vscode.window.showErrorMessage("This command requires a bundle file in the current workspace.");
+        return undefined;
+    }
+
+    const bundleQuickPicks = bundles.map(fileBundleSelection);
+
+    const bundlePick = await selectQuickPick(bundleQuickPicks, { placeHolder: prompt });
+    if (!bundlePick) {
+        return undefined;
+    }
+
+    return bundlePick;
+}
+
+export function fileBundleSelection(bundleFile: vscode.Uri): BundleSelection {
+    const bundleDir = path.dirname(path.dirname(bundleFile.fsPath));
+    return {
+        kind: 'folder',
+        label: path.basename(bundleDir),
+        path: bundleDir
+    };
+}
+
+export function repoBundleSelection(bundle: RepoBundle): BundleSelection {
+    return {
+        kind: 'repo',
+        label: bundle.name,
+        bundle: `${bundle.repository}/${bundle.name}`
+    };
+}

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -55,3 +55,7 @@ function trimPrefix(text: string, prefix: string): string {
 export async function refreshBundleExplorer(): Promise<void> {
     await vscode.commands.executeCommand("duffle.refreshBundleExplorer");
 }
+
+export async function refreshRepoExplorer(): Promise<void> {
+    await vscode.commands.executeCommand("duffle.refreshRepoExplorer");
+}


### PR DESCRIPTION
This PR adds a "Publish Bundle to Repo" command.  As the Duffle workflow around Git or HTTP based repos is not yet fully worked out, for now we implement this by copying the `bundle.json` to the local repository directory (under `$DUFFLE_HOME/repositories`).