### PR TITLE
Provide a way for users to add additional HTTP repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,13 @@
                         "duffle-path": {
                             "type": "string",
                             "description": "File path to a duffle binary"
+                        },
+                        "repositories": {
+                            "type": "array",
+                            "description": "Known bundle repositories",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,3 +13,7 @@ export function dufflePath(): string | undefined {
 export function toolPath(tool: string): string | undefined {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[`${tool}-path`];
 }
+
+export function repositories(): string[] {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)["repositories"] || [];
+}

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -50,7 +50,7 @@ export function list(sh: shell.Shell): Promise<Errorable<string[]>> {
 }
 
 export async function listRepos(sh: shell.Shell): Promise<Errorable<string[]>> {
-    return { succeeded: true, result: ["hub.cnlabs.io"] };
+    return { succeeded: true, result: ["hub.cnlabs.io"].concat(config.repositories()) };
 }
 
 export function listCredentialSets(sh: shell.Shell): Promise<Errorable<string[]>> {


### PR DESCRIPTION
This allows a user to register additional HTTP repos via the extension config, e.g.

```json
{
    "vscode-duffle": {
        "repositories": [
            "bundlehub2.azurewebsites.net"
        ]
    }
}
```

This may be a temporary solution if the CLI ends up including repo management; if it becomes permanent in the extension then we will add a proper UX around it.