### PR TITLE
Invoke `duffle credentials generate` non-interactively

### DIFF
--- a/src/commands/generatecredentials.ts
+++ b/src/commands/generatecredentials.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { longRunning, showDuffleResult, refreshCredentialExplorer } from '../utils/host';
 import * as duffle from '../duffle/duffle';
 import { RepoBundle, RepoBundleRef } from '../duffle/duffle.objectmodel';
+import * as dufflepaths from '../duffle/duffle.paths';
 import { succeeded, map, Errorable } from '../utils/errorable';
 import * as shell from '../utils/shell';
 import { cantHappen } from '../utils/never';
@@ -49,6 +50,7 @@ async function generateCredentialsCore(bundlePick: BundleSelection): Promise<voi
 
     if (succeeded(generateResult)) {
         await refreshCredentialExplorer();
+        await openCredentialSet(credentialSetName);
     }
 
     await showDuffleResult('generate credentials', (bundleId) => bundleId, generateResult);
@@ -68,4 +70,10 @@ async function generateCredentialsTo(bundlePick: BundleSelection, credentialSetN
         return map(installResult, (_) => bundlePick.bundle);
     }
     return cantHappen(bundlePick);
+}
+
+async function openCredentialSet(credentialSetName: string): Promise<void> {
+    const filePath = dufflepaths.credentialSetPath(credentialSetName);
+    const fileUri = vscode.Uri.file(filePath);
+    await vscode.commands.executeCommand("vscode.open", fileUri);
 }

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -149,9 +149,9 @@ export async function deleteCredentialSet(sh: shell.Shell, credentialSetName: st
 }
 
 export async function generateCredentialsForFile(sh: shell.Shell, bundleFilePath: string, name: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'credentials generate', `${name} -f "${bundleFilePath}"`, {}, (s) => null);
+    return await invokeObj(sh, 'credentials generate', `${name} -f "${bundleFilePath}" -q`, {}, (s) => null);
 }
 
 export async function generateCredentialsForBundle(sh: shell.Shell, bundleName: string, name: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'credentials generate', `${name} ${bundleName}`, {}, (s) => null);
+    return await invokeObj(sh, 'credentials generate', `${name} ${bundleName} -q`, {}, (s) => null);
 }


### PR DESCRIPTION
`duffle credentials generate` now prompts for each credential by default.  We don't really want this because we have a perfectly good editor right at hand, so we supply the `-q` switch to have it emit the credentialset directly without prompting.

Fixes #44.