### PR TITLE
Hide repo-related UI (explorer, push and pull)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "onCommand:duffle.exposeParameter",
         "onView:duffle.installationExplorer",
         "onView:duffle.bundleExplorer",
-        "onView:duffle.repoExplorer",
         "onView:duffle.credentialExplorer",
         "onLanguage:json"
     ],
@@ -233,7 +232,7 @@
                 },
                 {
                     "command": "duffle.push",
-                    "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle",
+                    "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle_TODO_REPO_restore_when_repos_land_for_real",
                     "group": "2"
                 },
                 {
@@ -288,7 +287,12 @@
                 },
                 {
                     "command": "duffle.pull",
-                    "when": "view == duffle.bundleExplorer && viewItem == duffle.repoBundle",
+                    "when": "view == duffle.repoExplorer && viewItem == duffle.repoBundle",
+                    "group": "2"
+                },
+                {
+                    "command": "duffle.push",
+                    "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle_TODO_REPO_restore_when_repos_land_for_real",
                     "group": "2"
                 },
                 {
@@ -343,10 +347,6 @@
                 {
                     "id": "duffle.bundleExplorer",
                     "name": "Bundles"
-                },
-                {
-                    "id": "duffle.repoExplorer",
-                    "name": "Repositories"
                 },
                 {
                     "id": "duffle.credentialExplorer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import { InstallationRef, CredentialSetRef, RepoBundleRef } from './duffle/duffle.objectmodel';
 import { InstallationExplorer } from './explorer/installation/installation-explorer';
 import { BundleExplorer } from './explorer/bundle/bundle-explorer';
-import { RepoExplorer } from './explorer/repo/repo-explorer';
 import { CredentialExplorer } from './explorer/credential/credential-explorer';
 import * as shell from './utils/shell';
 import * as duffle from './duffle/duffle';
@@ -25,7 +24,6 @@ const duffleDiagnostics = vscode.languages.createDiagnosticCollection("Duffle");
 export function activate(context: vscode.ExtensionContext) {
     const installationExplorer = new InstallationExplorer(shell.shell);
     const bundleExplorer = new BundleExplorer(shell.shell);
-    const repoExplorer = new RepoExplorer(shell.shell);
     const credentialExplorer = new CredentialExplorer(shell.shell);
     const duffleTOMLCompletionProvider = new DuffleTOMLCompletionProvider();
 
@@ -41,14 +39,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('duffle.install', install),
         vscode.commands.registerCommand('duffle.generateCredentials', generateCredentials),
         vscode.commands.registerCommand('duffle.refreshBundleExplorer', () => bundleExplorer.refresh()),
-        vscode.commands.registerCommand('duffle.refreshRepoExplorer', () => repoExplorer.refresh()),
+        vscode.commands.registerCommand('duffle.refreshRepoExplorer', () => { /* (TODO: REPO: restore when repos land for real) repoExplorer.refresh() */ }),
         vscode.commands.registerCommand('duffle.refreshCredentialExplorer', () => credentialExplorer.refresh()),
         vscode.commands.registerCommand('duffle.credentialsetAdd', credentialSetAdd),
         vscode.commands.registerCommand('duffle.credentialsetDelete', (node) => credentialsetDelete(node)),
         vscode.commands.registerCommand('duffle.exposeParameter', exposeParameter),
         vscode.window.registerTreeDataProvider("duffle.installationExplorer", installationExplorer),
         vscode.window.registerTreeDataProvider("duffle.bundleExplorer", bundleExplorer),
-        vscode.window.registerTreeDataProvider("duffle.repoExplorer", repoExplorer),
         vscode.window.registerTreeDataProvider("duffle.credentialExplorer", credentialExplorer),
         vscode.languages.registerCompletionItemProvider({ language: 'toml', pattern: '**/duffle.toml', scheme: 'file' }, duffleTOMLCompletionProvider)
     ];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/865538/49112562-fcfbbb80-f2f7-11e8-97b0-980b91749dde.png)

We are not landing repos on day one, but hope to have them back fairly soon, so for now we will hide the UI rather than deleting the code.