### PR TITLE
Basic project invocation image fails if 'run' file has CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/app/run eol=lf

--- a/projects/basic/cnab/app/run
+++ b/projects/basic/cnab/app/run
@@ -3,7 +3,7 @@
 #set -eo pipefail
 
 action=$CNAB_ACTION
-name=$CNAB_INSTALLATION_NAME 
+name=$CNAB_INSTALLATION_NAME
 
 case $action in
     install)


### PR DESCRIPTION
If the `run` file has CRLF life endings then the `docker run` of the invocation image fails with `standard_init_linux.go:190: exec user process caused "no such file or directory"`.  This PR forces the `run` file to have LF line endings.