### PR TITLE
CNAB WD and Duffle 0.2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.0
+
+* Compatibility update for Duffle 0.3.0 and the CNAB specification Working Draft
+
 ## 0.0.5
 
 * Fixed line ending issue in basic project template

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extension for developers building Cloud Native Application Bundles using the 
 * View your installed bundles
 * Create and populate Duffle credential sets
 
-This is an alpha release of the extension.  Please report any bugs or problems, and let us know if you have any suggestions or feature requests!  You can reach us via our [GitHub issues page](https://github.com/deislabs/duffle-vscode/issues).
+This is a beta release of the extension.  Please report any bugs or problems, and let us know if you have any suggestions or feature requests!  You can reach us via our [GitHub issues page](https://github.com/deislabs/duffle-vscode/issues).
 
 ## Getting started with the extension
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,37 @@
                 "readable-stream": "^2.3.5"
             }
         },
+        "cnabjs": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/cnabjs/-/cnabjs-0.0.3.tgz",
+            "integrity": "sha512-a92E/jvnP9JSM8QIQQBTu9NnZTLOORwoYuWeU9C5juBDNI0AzxPDJ3ql7SemdeqWXRN8IbGvWP5VZS7RfTpQuQ==",
+            "requires": {
+                "ajv": "^6.10.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+                }
+            }
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1897,6 +1928,21 @@
             "requires": {
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "through2-filter": "^3.0.0"
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                }
             }
         },
         "url-parse": {

--- a/package.json
+++ b/package.json
@@ -410,6 +410,7 @@
         "@types/request-promise-native": "^1.0.15",
         "@types/shelljs": "^0.8.0",
         "@types/tmp": "0.0.33",
+        "cnabjs": "0.0.3",
         "lodash": "^4.17.11",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "duffle-vscode",
     "displayName": "Duffle",
     "description": "Build and deploy Cloud Native Application Bundles with Duffle",
-    "version": "0.0.5",
+    "version": "0.3.0",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
         "onCommand:duffle.installationUninstall",
         "onCommand:duffle.createProject",
         "onCommand:duffle.build",
-        "onCommand:duffle.pull",
-        "onCommand:duffle.push",
         "onCommand:duffle.install",
         "onCommand:duffle.bundleDelete",
         "onCommand:duffle.export",
@@ -77,16 +75,6 @@
             {
                 "command": "duffle.build",
                 "title": "Build Bundle",
-                "category": "Duffle"
-            },
-            {
-                "command": "duffle.pull",
-                "title": "Pull Bundle",
-                "category": "Duffle"
-            },
-            {
-                "command": "duffle.push",
-                "title": "Push Bundle to Repo",
                 "category": "Duffle"
             },
             {
@@ -233,11 +221,6 @@
                     "group": "1"
                 },
                 {
-                    "command": "duffle.pull",
-                    "when": "view == duffle.repoExplorer && viewItem == duffle.repoBundle",
-                    "group": "2"
-                },
-                {
                     "command": "duffle.install",
                     "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle",
                     "group": "1"
@@ -256,11 +239,6 @@
                     "command": "duffle.export",
                     "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle",
                     "group": "2"
-                },
-                {
-                    "command": "duffle.push",
-                    "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle_TODO_REPO_restore_when_repos_land_for_real",
-                    "group": "3"
                 },
                 {
                     "command": "duffle.credentialsetDelete",
@@ -321,16 +299,6 @@
                     "command": "duffle.installationUninstall",
                     "when": "view == duffle.installationExplorer && viewItem = duffle.installation",
                     "group": "navigation"
-                },
-                {
-                    "command": "duffle.pull",
-                    "when": "view == duffle.repoExplorer && viewItem == duffle.repoBundle",
-                    "group": "2"
-                },
-                {
-                    "command": "duffle.push",
-                    "when": "view == duffle.bundleExplorer && viewItem == duffle.localBundle_TODO_REPO_restore_when_repos_land_for_real",
-                    "group": "2"
                 },
                 {
                     "command": "duffle.bundleDelete",

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -71,7 +71,7 @@ async function installCore(bundlePick: BundleSelection): Promise<void> {
         return;
     }
 
-    const parameterValues = await promptForParameters(bundlePick, manifest.result, 'Install', 'Enter installation parameters');
+    const parameterValues = await promptForParameters(bundlePick, manifest.result, 'install', 'Install', 'Enter installation parameters');
     if (parameterValues.cancelled) {
         return;
     }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,76 +1,76 @@
-import * as vscode from 'vscode';
+// import * as vscode from 'vscode';
 
-import { BundleSelection, localBundleSelection, promptLocalBundle } from '../utils/bundleselection';
-import { showDuffleResult, refreshRepoExplorer, longRunning } from '../utils/host';
-import { succeeded, Errorable, map, failed } from '../utils/errorable';
-import { cantHappen } from '../utils/never';
-import * as duffle from '../duffle/duffle';
-import * as shell from '../utils/shell';
-import { LocalBundleRef, LocalBundle } from '../duffle/duffle.objectmodel';
+// import { BundleSelection, localBundleSelection, promptLocalBundle } from '../utils/bundleselection';
+// import { showDuffleResult, refreshRepoExplorer, longRunning } from '../utils/host';
+// import { succeeded, Errorable, map, failed } from '../utils/errorable';
+// import { cantHappen } from '../utils/never';
+// import * as duffle from '../duffle/duffle';
+// import * as shell from '../utils/shell';
+// import { LocalBundleRef, LocalBundle } from '../duffle/duffle.objectmodel';
 
-export async function push(target?: any): Promise<void> {
-    if (!target) {
-        return await pushPrompted();
-    }
-    if (target.bundleLocation === 'local') {
-        return await pushLocalBundle((target as LocalBundleRef).bundle);
-    }
-    await vscode.window.showErrorMessage("Internal error: unexpected command target");
-}
+// export async function push(target?: any): Promise<void> {
+//     if (!target) {
+//         return await pushPrompted();
+//     }
+//     if (target.bundleLocation === 'local') {
+//         return await pushLocalBundle((target as LocalBundleRef).bundle);
+//     }
+//     await vscode.window.showErrorMessage("Internal error: unexpected command target");
+// }
 
-async function pushPrompted(): Promise<void> {
-    const bundlePick = await promptLocalBundle("Select the bundle to push");
+// async function pushPrompted(): Promise<void> {
+//     const bundlePick = await promptLocalBundle("Select the bundle to push");
 
-    if (!bundlePick) {
-        return;
-    }
+//     if (!bundlePick) {
+//         return;
+//     }
 
-    return await pushCore(bundlePick);
-}
+//     return await pushCore(bundlePick);
+// }
 
-async function pushLocalBundle(bundle: LocalBundle): Promise<void> {
-    return await pushCore(localBundleSelection(bundle));
-}
+// async function pushLocalBundle(bundle: LocalBundle): Promise<void> {
+//     return await pushCore(localBundleSelection(bundle));
+// }
 
-async function pushCore(bundlePick: BundleSelection): Promise<void> {
-    const name = bundlePick.kind === 'file' ? await promptRepo(shell.shell, `Push bundle in ${bundlePick.label} to...`) : 'UNUSED';
-    if (!name) {
-        return;
-    }
+// async function pushCore(bundlePick: BundleSelection): Promise<void> {
+//     const name = bundlePick.kind === 'file' ? await promptRepo(shell.shell, `Push bundle in ${bundlePick.label} to...`) : 'UNUSED';
+//     if (!name) {
+//         return;
+//     }
 
-    const pushResult = await pushTo(bundlePick, name);
+//     const pushResult = await pushTo(bundlePick, name);
 
-    if (succeeded(pushResult)) {
-        await refreshRepoExplorer();
-    }
+//     if (succeeded(pushResult)) {
+//         await refreshRepoExplorer();
+//     }
 
-    await showDuffleResult('push', (bundleId) => bundleId, pushResult);
-}
+//     await showDuffleResult('push', (bundleId) => bundleId, pushResult);
+// }
 
-async function pushTo(bundlePick: BundleSelection, repo: string): Promise<Errorable<string>> {
-    if (bundlePick.kind === 'file') {
-        return { succeeded: false, error: ['Internal error - cannot push filesystem bundles - import it first'] };
-    } else if (bundlePick.kind === 'repo') {
-        return { succeeded: false, error: ['Internal error - cannot push bundles already in repos'] };
-    } else if (bundlePick.kind === 'local') {
-        const pushResult = await longRunning(`Duffle push ${bundlePick.bundle}`,
-            () => duffle.pushBundle(shell.shell, bundlePick.bundle)
-        );
-        return map(pushResult, (_) => bundlePick.bundle);
-    }
-    return cantHappen(bundlePick);
-}
+// async function pushTo(bundlePick: BundleSelection, repo: string): Promise<Errorable<string>> {
+//     if (bundlePick.kind === 'file') {
+//         return { succeeded: false, error: ['Internal error - cannot push filesystem bundles - import it first'] };
+//     } else if (bundlePick.kind === 'repo') {
+//         return { succeeded: false, error: ['Internal error - cannot push bundles already in repos'] };
+//     } else if (bundlePick.kind === 'local') {
+//         const pushResult = await longRunning(`Duffle push ${bundlePick.bundle}`,
+//             () => duffle.pushBundle(shell.shell, bundlePick.bundle)
+//         );
+//         return map(pushResult, (_) => bundlePick.bundle);
+//     }
+//     return cantHappen(bundlePick);
+// }
 
-async function promptRepo(shell: shell.Shell, prompt: string): Promise<string | undefined> {
-    const repos = await duffle.listRepos(shell);
-    if (failed(repos)) {
-        vscode.window.showErrorMessage("Unable to list repos to which you can push");
-        return undefined;
-    }
-    if (!repos.result || !repos.result.length) {
-        vscode.window.showErrorMessage("You don't have any repos to which you can push");
-        return undefined;
-    }
-    const repo = await vscode.window.showQuickPick(repos.result, { placeHolder: prompt });
-    return repo;
-}
+// async function promptRepo(shell: shell.Shell, prompt: string): Promise<string | undefined> {
+//     const repos = await duffle.listRepos(shell);
+//     if (failed(repos)) {
+//         vscode.window.showErrorMessage("Unable to list repos to which you can push");
+//         return undefined;
+//     }
+//     if (!repos.result || !repos.result.length) {
+//         vscode.window.showErrorMessage("You don't have any repos to which you can push");
+//         return undefined;
+//     }
+//     const repo = await vscode.window.showQuickPick(repos.result, { placeHolder: prompt });
+//     return repo;
+// }

--- a/src/duffle/duffle.objectmodel.ts
+++ b/src/duffle/duffle.objectmodel.ts
@@ -1,3 +1,5 @@
+import * as cnab from 'cnabjs';
+
 export interface InstallationRef {
     readonly installationName: string;
 }
@@ -31,31 +33,12 @@ export interface LocalBundle {
     readonly digest?: string;  // always present in CLI, but sometimes we need to cons up one of these in code, and since we never use the digest property...
 }
 
-export interface ParameterDefinition {
-    readonly type: string;
-    readonly allowedValues?: (number | string | boolean)[];
-    readonly defaultValue?: number | string | boolean;
-    readonly metadata?: { description?: string };
-}
-
-export interface CredentialLocation {
-    readonly env?: string;
-    readonly path?: string;
-}
-
 export interface CredentialSetRef {
     readonly credentialSetName: string;
 }
 
-export interface BundleManifest {
-    readonly name: string;
-    readonly version: string;
-    readonly parameters?: { [key: string]: ParameterDefinition };
-    readonly credentials?: { [key: string]: CredentialLocation };
-}
-
 export interface Claim {
     readonly name: string;
-    readonly bundle: BundleManifest;
+    readonly bundle: cnab.Bundle;
     // Ignoring other fields for now
 }

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as config from '../config/config';
 import { Errorable } from '../utils/errorable';
 import * as shell from '../utils/shell';
-import { RepoBundle, LocalBundle, Claim } from './duffle.objectmodel';
+import { LocalBundle, Claim } from './duffle.objectmodel';
 import { sharedTerminal } from './sharedterminal';
 import * as pairs from '../utils/pairs';
 import * as buildDefinition from './builddefinition';
@@ -61,16 +61,6 @@ export function listCredentialSets(sh: shell.Shell): Promise<Errorable<string[]>
             .filter((l) => l.length > 0);
     }
     return invokeObj(sh, 'credentials list', '--short', {}, parse);
-}
-
-export function search(sh: shell.Shell): Promise<Errorable<RepoBundle[]>> {
-    function parse(stdout: string): RepoBundle[] {
-        const lines = stdout.split('\n')
-            .map((l) => l.trim())
-            .filter((l) => l.length > 0);
-        return fromHeaderedTable<RepoBundle>(lines).map((b) => ({ repository: "hub.cnlabs.io", ...b }));
-    }
-    return invokeObj(sh, 'search', '', {}, parse);
 }
 
 export function bundles(sh: shell.Shell): Promise<Errorable<LocalBundle[]>> {

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -91,7 +91,7 @@ export async function pull(sh: shell.Shell, bundleName: string): Promise<Errorab
 
 export async function exportFile(sh: shell.Shell, bundleFilePath: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {
     const modeFlag = thick ? '' : '-t';
-    return await invokeObj(sh, 'export', `"${bundleFilePath}" -s ${modeFlag} -o "${outputFile}"`, {}, (_) => null);
+    return await invokeObj(sh, 'export', `"${bundleFilePath}" -f ${modeFlag} -o "${outputFile}"`, {}, (_) => null);
 }
 
 export async function exportBundle(sh: shell.Shell, bundleName: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -81,13 +81,13 @@ export async function uninstall(sh: shell.Shell, bundleName: string, credentialS
     return await invokeObj(sh, 'uninstall', `${bundleName} ${credentialArg(credentialSet)}`, {}, (s) => null);
 }
 
-export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'push', `${bundleName}`, {}, (s) => null);
-}
+// export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
+//     return await invokeObj(sh, 'push', `${bundleName}`, {}, (s) => null);
+// }
 
-export async function pull(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'pull', `${bundleName}`, {}, (s) => null);
-}
+// export async function pull(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
+//     return await invokeObj(sh, 'pull', `${bundleName}`, {}, (s) => null);
+// }
 
 export async function exportFile(sh: shell.Shell, bundleFilePath: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {
     const modeFlag = thick ? '' : '-t';

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -74,11 +74,11 @@ export function bundles(sh: shell.Shell): Promise<Errorable<LocalBundle[]>> {
 }
 
 export async function upgrade(sh: shell.Shell, bundleName: string, credentialSet: string | undefined): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'upgrade', `${bundleName} ${credentialArg(credentialSet)} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'upgrade', `${bundleName} ${credentialArg(credentialSet)}`, {}, (s) => null);
 }
 
 export async function uninstall(sh: shell.Shell, bundleName: string, credentialSet: string | undefined): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'uninstall', `${bundleName} ${credentialArg(credentialSet)} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'uninstall', `${bundleName} ${credentialArg(credentialSet)}`, {}, (s) => null);
 }
 
 export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
@@ -86,17 +86,17 @@ export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<E
 }
 
 export async function pull(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'pull', `${bundleName} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'pull', `${bundleName}`, {}, (s) => null);
 }
 
 export async function exportFile(sh: shell.Shell, bundleFilePath: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {
     const modeFlag = thick ? '' : '-t';
-    return await invokeObj(sh, 'export', `"${bundleFilePath}" -s ${modeFlag} -o "${outputFile}" --insecure`, {}, (_) => null);
+    return await invokeObj(sh, 'export', `"${bundleFilePath}" -s ${modeFlag} -o "${outputFile}"`, {}, (_) => null);
 }
 
 export async function exportBundle(sh: shell.Shell, bundleName: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {
     const modeFlag = thick ? '' : '-t';
-    return await invokeObj(sh, 'export', `${bundleName} ${modeFlag} -o "${outputFile}" --insecure`, {}, (_) => null);
+    return await invokeObj(sh, 'export', `${bundleName} ${modeFlag} -o "${outputFile}"`, {}, (_) => null);
 }
 
 export async function getClaim(sh: shell.Shell, claimName: string): Promise<Errorable<Claim>> {
@@ -116,11 +116,11 @@ export async function build(sh: shell.Shell, folderPath: string): Promise<Errora
 }
 
 export async function installFile(sh: shell.Shell, bundleFilePath: string, name: string, params: { [key: string]: string }, credentialSet: string | undefined): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'install', `${name} "${bundleFilePath}" -f ${paramsArgs(params)} ${credentialArg(credentialSet)} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'install', `${name} "${bundleFilePath}" -f ${paramsArgs(params)} ${credentialArg(credentialSet)}`, {}, (s) => null);
 }
 
 export async function installBundle(sh: shell.Shell, bundleName: string, name: string, params: { [key: string]: string }, credentialSet: string | undefined): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'install', `${name} ${bundleName} ${paramsArgs(params)} ${credentialArg(credentialSet)} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'install', `${name} ${bundleName} ${paramsArgs(params)} ${credentialArg(credentialSet)}`, {}, (s) => null);
 }
 
 export async function deleteBundle(sh: shell.Shell, bundleName: string, version: string | undefined): Promise<Errorable<null>> {
@@ -172,9 +172,9 @@ export async function deleteCredentialSet(sh: shell.Shell, credentialSetName: st
 }
 
 export async function generateCredentialsForFile(sh: shell.Shell, bundleFilePath: string, name: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'credentials generate', `${name} -f "${bundleFilePath}" -q --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'credentials generate', `${name} -f "${bundleFilePath}" -q`, {}, (s) => null);
 }
 
 export async function generateCredentialsForBundle(sh: shell.Shell, bundleName: string, name: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'credentials generate', `${name} ${bundleName} -q --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'credentials generate', `${name} ${bundleName} -q`, {}, (s) => null);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,21 +2,19 @@
 
 import * as vscode from 'vscode';
 
-import { InstallationRef, CredentialSetRef, RepoBundleRef, LocalBundleRef } from './duffle/duffle.objectmodel';
+import { InstallationRef, CredentialSetRef, LocalBundleRef } from './duffle/duffle.objectmodel';
 import { InstallationExplorer } from './explorer/installation/installation-explorer';
 import { BundleExplorer } from './explorer/bundle/bundle-explorer';
 import { CredentialExplorer } from './explorer/credential/credential-explorer';
 import * as shell from './utils/shell';
 import * as duffle from './duffle/duffle';
 import { selectWorkspaceFolder, longRunning, showDuffleResult, refreshInstallationExplorer, refreshCredentialExplorer, confirm, refreshBundleExplorer } from './utils/host';
-import { push } from './commands/push';
 import { install } from './commands/install';
 import { lintTo } from './lint/linters';
 import { succeeded, failed } from './utils/errorable';
 import { selectProjectCreator } from './projects/ui';
 import { exposeParameter } from './commands/exposeparameter';
 import { generateCredentials } from './commands/generatecredentials';
-import { repoBundleRef } from './utils/bundleselection';
 import { promptForCredentials } from './utils/credentials';
 import { Reporter } from './utils/telemetry';
 import * as telemetry from './utils/telemetry-helper';
@@ -36,8 +34,8 @@ export function activate(context: vscode.ExtensionContext) {
         registerCommand('duffle.installationUninstall', (node) => installationUninstall(node)),
         registerCommand('duffle.createProject', createProject),
         registerCommand('duffle.build', build),
-        registerCommand('duffle.pull', pull),
-        registerCommand('duffle.push', push),
+        // registerCommand('duffle.pull', pull),
+        // registerCommand('duffle.push', push),
         registerCommand('duffle.install', install),
         registerCommand('duffle.bundleDelete', (node) => bundleDelete(node)),
         registerCommand('duffle.export', exportBundle),
@@ -174,18 +172,18 @@ async function installationUninstall(bundle: InstallationRef): Promise<void> {
     });
 }
 
-async function pull(repoBundle: RepoBundleRef): Promise<void> {
-    const bundleName = repoBundleRef(repoBundle.bundle);
-    const pullResult = await longRunning(`Duffle pulling ${bundleName}`, () =>
-        duffle.pull(shell.shell, bundleName)
-    );
+// async function pull(repoBundle: RepoBundleRef): Promise<void> {
+//     const bundleName = repoBundleRef(repoBundle.bundle);
+//     const pullResult = await longRunning(`Duffle pulling ${bundleName}`, () =>
+//         duffle.pull(shell.shell, bundleName)
+//     );
 
-    if (succeeded(pullResult)) {
-        await refreshBundleExplorer();
-    }
+//     if (succeeded(pullResult)) {
+//         await refreshBundleExplorer();
+//     }
 
-    await showDuffleResult('pull', bundleName, pullResult);
-}
+//     await showDuffleResult('pull', bundleName, pullResult);
+// }
 
 async function bundleDelete(bundle: LocalBundleRef): Promise<void> {
     const bundleName = bundle.bundle.name;

--- a/src/lint/duffle.builddefinition.linters.ts
+++ b/src/lint/duffle.builddefinition.linters.ts
@@ -1,115 +1,122 @@
-import * as vscode from 'vscode';
+// import * as vscode from 'vscode';
 
-import { Linter } from './linters';
-import * as buildDefinition from '../duffle/builddefinition';
-import { subdirectoriesFromFile } from '../utils/fsutils';
-import { iter, Enumerable } from '../utils/iterable';
-import { getSymbols, WithSymbol } from '../utils/symbols';
-import { Pair, fromMap } from '../utils/pairs';
+// import { Linter } from './linters';
+// import * as buildDefinition from '../duffle/builddefinition';
+// import { subdirectoriesFromFile } from '../utils/fsutils';
+// import { iter, Enumerable } from '../utils/iterable';
+// import { getSymbols, WithSymbol } from '../utils/symbols';
+// import { Pair, fromMap } from '../utils/pairs';
 
-export class InvocationImageNameMustBeSubdirectory implements Linter {
-    canLint(document: vscode.TextDocument): boolean {
-        return isDuffleBuildDefinition(document);
-    }
+// export class InvocationImageNameMustBeSubdirectory implements Linter {
+//     canLint(document: vscode.TextDocument): boolean {
+//         return isDuffleBuildDefinition(document);
+//     }
 
-    async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
-        if (document.uri.scheme !== 'file') {
-            return [];
-        }
+//     async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+//         if (document.uri.scheme !== 'file') {
+//             return [];
+//         }
 
-        const buildDefinitionPath = document.uri.fsPath;
-        const subdirectories = subdirectoriesFromFile(buildDefinitionPath);
+//         const buildDefinitionPath = document.uri.fsPath;
+//         const subdirectories = subdirectoriesFromFile(buildDefinitionPath);
 
-        const symbols = invocationImageSymbols(await getSymbols(document));
+//         const symbols = invocationImageSymbols(await getSymbols(document));
 
-        const diagnostics =
-            invocationImages(document)
-                .filter((m) => !isPresent(m.key, subdirectories))
-                .map((m) => invocationImageSymbol(symbols, m))
-                .map((m) => makeNotSubdirectoryDiagnostic(m.symbol.selectionRange, m.value.key));
+//         const diagnostics =
+//             invocationImages(document)
+//                 .filter((m) => !isPresent(m.key, subdirectories))
+//                 .map((m) => invocationImageSymbol(symbols, m))
+//                 .filter((m) => !!m.symbol)
+//                 .map((m) => makeNotSubdirectoryDiagnostic(m.symbol!.selectionRange, m.value.key));
 
-        return diagnostics.toArray();
-    }
-}
+//         return diagnostics.toArray();
+//     }
+// }
 
-export class InvocationImageNameMustMatchNameElement implements Linter {
-    canLint(document: vscode.TextDocument): boolean {
-        return isDuffleBuildDefinition(document);
-    }
+// export class InvocationImageNameMustMatchNameElement implements Linter {
+//     canLint(document: vscode.TextDocument): boolean {
+//         return isDuffleBuildDefinition(document);
+//     }
 
-    async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
-        const symbols = invocationImageSymbols(await getSymbols(document));
+//     async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+//         const symbols = invocationImageSymbols(await getSymbols(document));
 
-        const diagnostics =
-            invocationImages(document)
-                .map((m) => invocationImageSymbol(symbols, m))
-                .collect((m) => nameDiagnostics(m, document));
+//         const diagnostics =
+//             invocationImages(document)
+//                 .map((m) => invocationImageSymbol(symbols, m))
+//                 .collect((m) => nameDiagnostics(m, document));
 
-        return diagnostics.toArray();
-    }
-}
+//         return diagnostics.toArray();
+//     }
+// }
 
-function invocationImageSymbols(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] {
-    const parent = symbols.find((s) => s.name === "invocationImages");
-    return parent ? parent.children : [];
-}
+// function invocationImageSymbols(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] {
+//     const parent = symbols.find((s) => s.name === "invocationImages");
+//     return parent ? parent.children : [];
+// }
 
-function invocationImageSymbol(symbols: vscode.DocumentSymbol[], image: Pair<InvocationImage>): WithSymbol<Pair<InvocationImage>> {
-    return { value: image, symbol: symbols.find((s) => s.name === image.key)! };
-}
+// function invocationImageSymbol(symbols: vscode.DocumentSymbol[], image: Pair<InvocationImage>): WithSymbol<Pair<InvocationImage>> {
+//     // TODO: this feels like we are mishandling an early stage where the symbols are not
+//     // yet available - worry is we could fail to display diagnostics and they wouldn't
+//     // appear until the document is edited
+//     return { value: image, symbol: symbols.find((s) => s.name === image.key) };
+// }
 
-interface InvocationImage {
-    readonly name: string;
-}
+// interface InvocationImage {
+//     readonly name: string;
+// }
 
-function isDuffleBuildDefinition(document: vscode.TextDocument): boolean {
-    return document.languageId === buildDefinition.languageId && document.uri.toString().endsWith(buildDefinition.definitionFile);
-}
+// function isDuffleBuildDefinition(document: vscode.TextDocument): boolean {
+//     return document.languageId === buildDefinition.languageId && document.uri.toString().endsWith(buildDefinition.definitionFile);
+// }
 
-function invocationImages(document: vscode.TextDocument): Enumerable<Pair<InvocationImage>> {
-    return iter(invocationImagesCore(document));
-}
+// function invocationImages(document: vscode.TextDocument): Enumerable<Pair<InvocationImage>> {
+//     return iter(invocationImagesCore(document));
+// }
 
-function invocationImagesCore(document: vscode.TextDocument): Pair<InvocationImage>[] {
-    try {
-        const buildDef = JSON.parse(document.getText());
-        if (buildDef) {
-            return fromMap<InvocationImage>(buildDef.invocationImages);
-        }
-        return [];
-    } catch {
-        return [];  // text may be temporarily invalid due to edit in progress
-    }
-}
+// function invocationImagesCore(document: vscode.TextDocument): Pair<InvocationImage>[] {
+//     try {
+//         const buildDef = JSON.parse(document.getText());
+//         if (buildDef) {
+//             return fromMap<InvocationImage>(buildDef.invocationImages);
+//         }
+//         return [];
+//     } catch {
+//         return [];  // text may be temporarily invalid due to edit in progress
+//     }
+// }
 
-function isPresent(name: string, candidates: string[]): boolean {
-    return candidates.indexOf(name) >= 0;
-}
+// function isPresent(name: string, candidates: string[]): boolean {
+//     return candidates.indexOf(name) >= 0;
+// }
 
-function* nameDiagnostics(image: WithSymbol<Pair<InvocationImage>>, document: vscode.TextDocument): IterableIterator<vscode.Diagnostic> {
-    const nameSymbol = findNameSymbol(image.symbol);
-    if (!nameSymbol) {
-        yield makeNoNameDiagnostic(image.symbol.selectionRange);
-        return;
-    }
-    const invocationImage = image.value;
-    if (invocationImage.key !== invocationImage.value.name) {
-        yield makeNameMismatchDiagnostic(nameSymbol.range, invocationImage.key, invocationImage.value.name);
-    }
-}
+// function* nameDiagnostics(image: WithSymbol<Pair<InvocationImage>>, document: vscode.TextDocument): IterableIterator<vscode.Diagnostic> {
+//     if (!image.symbol) {
+//         return;
+//     }
+//     const nameSymbol = findNameSymbol(image.symbol);
+//     if (!nameSymbol) {
+//         yield makeNoNameDiagnostic(image.symbol.selectionRange);
+//         return;
+//     }
+//     const invocationImage = image.value;
+//     if (invocationImage.key !== invocationImage.value.name) {
+//         yield makeNameMismatchDiagnostic(nameSymbol.range, invocationImage.key, invocationImage.value.name);
+//     }
+// }
 
-function findNameSymbol(imageSymbol: vscode.DocumentSymbol): vscode.DocumentSymbol | undefined {
-    return imageSymbol.children.find((s) => s.name === "name");
-}
+// function findNameSymbol(imageSymbol: vscode.DocumentSymbol): vscode.DocumentSymbol | undefined {
+//     return imageSymbol.children.find((s) => s.name === "name");
+// }
 
-function makeNotSubdirectoryDiagnostic(range: vscode.Range, name: string): vscode.Diagnostic {
-    return new vscode.Diagnostic(range, `${name} is not a subdirectory`, vscode.DiagnosticSeverity.Warning);
-}
+// function makeNotSubdirectoryDiagnostic(range: vscode.Range, name: string): vscode.Diagnostic {
+//     return new vscode.Diagnostic(range, `${name} is not a subdirectory`, vscode.DiagnosticSeverity.Warning);
+// }
 
-function makeNoNameDiagnostic(range: vscode.Range) {
-    return new vscode.Diagnostic(range, `Image specification does not contain a 'name' element`, vscode.DiagnosticSeverity.Warning);
-}
+// function makeNoNameDiagnostic(range: vscode.Range) {
+//     return new vscode.Diagnostic(range, `Image specification does not contain a 'name' element`, vscode.DiagnosticSeverity.Warning);
+// }
 
-function makeNameMismatchDiagnostic(range: vscode.Range, titleName: string, containedName: string) {
-    return new vscode.Diagnostic(range, `Image name ${titleName} does not match 'name' element ${containedName}`, vscode.DiagnosticSeverity.Warning);
-}
+// function makeNameMismatchDiagnostic(range: vscode.Range, titleName: string, containedName: string) {
+//     return new vscode.Diagnostic(range, `Image name ${titleName} does not match 'name' element ${containedName}`, vscode.DiagnosticSeverity.Warning);
+// }

--- a/src/lint/linters.ts
+++ b/src/lint/linters.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import * as buildDefinition from './duffle.builddefinition.linters';
+// import * as buildDefinition from './duffle.builddefinition.linters';
 
 export interface Linter {
     canLint(document: vscode.TextDocument): boolean;
@@ -8,8 +8,8 @@ export interface Linter {
 }
 
 const linters: Linter[] = [
-    new buildDefinition.InvocationImageNameMustBeSubdirectory(),
-    new buildDefinition.InvocationImageNameMustMatchNameElement()
+    // new buildDefinition.InvocationImageNameMustBeSubdirectory(),
+    // new buildDefinition.InvocationImageNameMustMatchNameElement()
 ];
 
 export function lintTo(dc: vscode.DiagnosticCollection): (document: vscode.TextDocument) => Promise<void> {

--- a/src/utils/bundleselection.ts
+++ b/src/utils/bundleselection.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as request from 'request-promise-native';
+import * as cnab from 'cnabjs';
 
 import { selectQuickPick } from './host';
-import { RepoBundle, BundleManifest, LocalBundle } from '../duffle/duffle.objectmodel';
+import { RepoBundle, LocalBundle } from '../duffle/duffle.objectmodel';
 import { cantHappen } from './never';
 import { fs } from './fs';
 import { Errorable, map, failed } from './errorable';
@@ -33,7 +34,7 @@ export interface LocalBundleSelection {
 export type BundleSelection = FileBundleSelection | RepoBundleSelection | LocalBundleSelection;
 
 export interface BundleContent {
-    readonly manifest: BundleManifest;
+    readonly manifest: cnab.Bundle;
     readonly text: string;
 }
 
@@ -119,7 +120,7 @@ export async function bundleContent(bundlePick: BundleSelection): Promise<Errora
     });
 }
 
-export async function bundleManifest(bundlePick: BundleSelection): Promise<Errorable<BundleManifest>> {
+export async function bundleManifest(bundlePick: BundleSelection): Promise<Errorable<cnab.Bundle>> {
     const content = await bundleContent(bundlePick);
     return map(content, (c) => c.manifest);
 }

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
+import * as cnab from 'cnabjs';
 
 import * as duffle from '../duffle/duffle';
 import { Cancellable } from './cancellable';
 import { Shell } from './shell';
 import { failed } from './errorable';
-import { BundleManifest } from '../duffle/duffle.objectmodel';
 
-export async function promptForCredentials(bundleManifest: BundleManifest, sh: Shell, prompt: string): Promise<Cancellable<string | undefined>> {
+export async function promptForCredentials(bundleManifest: cnab.Bundle, sh: Shell, prompt: string): Promise<Cancellable<string | undefined>> {
     if (!(await hasCredentials(bundleManifest))) {
         return { cancelled: false, value: undefined };
     }
@@ -29,7 +29,7 @@ export async function promptForCredentials(bundleManifest: BundleManifest, sh: S
     return { cancelled: false, value: credentialSet };
 }
 
-async function hasCredentials(manifest: BundleManifest): Promise<boolean> {
+async function hasCredentials(manifest: cnab.Bundle): Promise<boolean> {
     const credentials = manifest.credentials || {};
     return Object.keys(credentials).length > 0;
 }

--- a/src/utils/parameters.ts
+++ b/src/utils/parameters.ts
@@ -50,6 +50,10 @@ function parameterEntryRow(p: ParameterDefinitionMapping): string {
 }
 
 function inputWidget(p: ParameterDefinitionMapping): string {
+    if (!p.schema) {
+        // This doesn't need to be fancy as it should never happen
+        return `<input name="${p.name}" type="text" />`;
+    }
     if (p.schema.type === "boolean") {
         return `<select name="${p.name}"><option>True</option><option>False</option></select>`;
     }

--- a/src/utils/parameters.ts
+++ b/src/utils/parameters.ts
@@ -1,16 +1,18 @@
-import { ParameterDefinition, BundleManifest } from "../duffle/duffle.objectmodel";
+import * as cnab from "cnabjs";
+
 import { BundleSelection } from "./bundleselection";
 import { END_DIALOG_FN, dialog } from "./dialog";
 import { Cancellable } from './cancellable';
 
 export type ParameterValuesPromptResult = Cancellable<{ [key: string]: string }>;
 
-interface ParameterDefinitionMapping extends ParameterDefinition {
+interface ParameterDefinitionMapping extends cnab.Parameter {
     readonly name: string;
+    readonly schema: cnab.Definition;
 }
 
-export async function promptForParameters(bundlePick: BundleSelection, bundleManifest: BundleManifest, actionName: string, prompt: string): Promise<ParameterValuesPromptResult> {
-    const definitions = parseParameters(bundleManifest);
+export async function promptForParameters(bundlePick: BundleSelection, bundleManifest: cnab.Bundle, actionId: string, actionDisplayName: string, prompt: string): Promise<ParameterValuesPromptResult> {
+    const definitions = parseParameters(bundleManifest, actionId);
     if (!definitions || definitions.length === 0) {
         return { cancelled: false, value: {} };
     }
@@ -21,9 +23,9 @@ export async function promptForParameters(bundlePick: BundleSelection, bundleMan
     <form id='${parameterFormId}'>
     ${parameterEntryTable(definitions)}
     </form>
-    <p><button onclick='${END_DIALOG_FN}'>${actionName}</button></p>`;
+    <p><button onclick='${END_DIALOG_FN}'>${actionDisplayName}</button></p>`;
 
-    const parameterValues = await dialog(`${actionName} ${bundlePick.label}`, html, parameterFormId);
+    const parameterValues = await dialog(`${actionDisplayName} ${bundlePick.label}`, html, parameterFormId);
     if (!parameterValues) {
         return { cancelled: true };
     }
@@ -42,30 +44,33 @@ function parameterEntryRow(p: ParameterDefinitionMapping): string {
     <td>${inputWidget(p)}</td>
 </tr>
 <tr>
-    <td colspan="2" style="font-size:80%">${p.metadata ? (p.metadata.description || '') : ''}</td>
+    <td colspan="2" style="font-size:80%">${p.description || ''}</td>
 </tr>
 `;
 }
 
 function inputWidget(p: ParameterDefinitionMapping): string {
-    if (p.type === "bool") {
+    if (p.schema.type === "boolean") {
         return `<select name="${p.name}"><option>True</option><option>False</option></select>`;
     }
-    if (p.allowedValues) {
-        const opts = p.allowedValues.map((av) => `<option>${av}</option>`).join('');
+    if (p.schema.enum) {
+        const opts = p.schema.enum.map((av) => `<option>${av}</option>`).join('');
         return `<select name="${p.name}">${opts}</select>`;
     }
-    const defval = p.defaultValue ? `${p.defaultValue}` : '';
+    const defval = p.schema.default ? `${p.schema.default}` : '';
     return `<input name="${p.name}" type="text" value="${defval}" />`;
 }
 
-function parseParameters(manifest: BundleManifest): ParameterDefinitionMapping[] {
-    const parameters = manifest.parameters;
-    const defs: ParameterDefinitionMapping[] = [];
-    if (parameters) {
-        for (const k in parameters) {
-            defs.push({ name: k, ...parameters[k] });
-        }
+function parseParameters(bundle: cnab.Bundle, action: string): ParameterDefinitionMapping[] {
+    const parameters = bundle.parameters;
+    const schemas = bundle.definitions;
+    if (!parameters || !schemas) {
+        return [];
     }
+
+    const actionParameters = cnab.Parameters.forAction(bundle, action);
+    const parameterSequence = Array.of(...actionParameters).sort();
+
+    const defs = parameterSequence.map((k) => ({ name: k, schema: schemas[parameters[k].definition], ...parameters[k] }));
     return defs;
 }

--- a/src/utils/symbols.ts
+++ b/src/utils/symbols.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 export interface WithSymbol<T> {
     readonly value: T;
-    readonly symbol: vscode.DocumentSymbol;
+    readonly symbol: vscode.DocumentSymbol | undefined;
 }
 
 export interface SymbolInContext {


### PR DESCRIPTION
This upgrades the extension to handle WD-compliant bundles, and to use Duffle 0.2.0 CLI syntax.  It removes features and commands (such as signing) no longer supported by Duffle.

~NOTE: *Duffle 0.2.0 does not yet comply with the CNAB WD.*  This PR needs to wait for a compliant Duffle rev, or will need to be revisited to work with the old format.~  Duffle 0.3.0 complies